### PR TITLE
Fix conference link, Update Speakers & Automate Conference Deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: yarn install & deploy
+      - name: yarn install & deploy global
         run: |
           yarn install --frozen-lockfile
           yarn deploy:global
@@ -43,3 +43,43 @@ jobs:
           password: ${{ secrets.FTP_PASSWORD }}
           localDir: 'public'
           remoteDir: 'public_html'
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [15.x]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: yarn install & deploy conference
+        run: |
+          yarn install --frozen-lockfile
+          yarn deploy:conference
+      - name: Upload public dir
+        uses: actions/upload-artifact@v1
+        with:
+          name: public
+          path: apps/conference/public
+        env:
+          CI: true
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Download public dir
+        uses: actions/download-artifact@v1
+        with:
+          name: public
+      - name: Upload ftp
+        uses: sebastianpopp/ftp-action@releases/v1
+        with:
+          host: ${{ secrets.FTP_SERVER }}
+          user: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          localDir: 'public'
+          remoteDir: 'conference.dreamon.world'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,6 +40,10 @@ jobs:
       - name: Run Global E2E Tests
         run: yarn e2e:global:ci
 
+      # Run conference e2e tests
+      - name: Run Conference E2E Tests
+        run: yarn e2e:conference:ci
+
       #Run unit tests on codemods lib
       - name: Build
         run: yarn build:affected --base=origin/master

--- a/apps/conference-e2e/src/integration/app.spec.ts
+++ b/apps/conference-e2e/src/integration/app.spec.ts
@@ -1,13 +1,7 @@
-import { getGreeting } from '../support/app.po'
-
 describe('conference', () => {
   beforeEach(() => cy.visit('/'))
 
-  it('should display welcome message', () => {
-    // Custom command example, see `../support/commands.ts` file
-    cy.login('my-email@something.com', 'myPassword')
-
-    // Function helper example, see `../support/app.po.ts` file
-    getGreeting().contains('Welcome to conference!')
+  it('should load home page', () => {
+    cy.get('h1').contains('Dream On: Conference 2022')
   })
 })

--- a/apps/conference/src/components/speakers.tsx
+++ b/apps/conference/src/components/speakers.tsx
@@ -51,6 +51,21 @@ const features = [
     description:
       'Rob Kennedy serves as the Senior Pastor at The Rock Community Church & Transformation Center in Saint Petersburg Florida as well as Dream On: Speaker Collective Speaker and Author',
   },
+  {
+    name: 'Judy Zircher',
+    description:
+      'Judy Zircher is the Abstinence Educator at Relationships Under Construction as well as the Founder of Purity Ally and Dream On: Speaker Collective Speaker and Author',
+  },
+  {
+    name: 'Jason Harris',
+    description:
+      'Jason Harris is the Host of the Forecast Podcast and a Dream On: Speaker Collective Speaker',
+  },
+  {
+    name: 'Craig Flack',
+    description:
+      'Craig Flack is the Senior Pastor of Celina First Church of God, Former School Board President and Author',
+  },
 ]
 
 const Speakers = () => {

--- a/apps/global/src/components/slider.tsx
+++ b/apps/global/src/components/slider.tsx
@@ -55,7 +55,7 @@ const Slider = (): ReactElement => {
                       <span>{translations.one.button}</span>
                     </OutboundLink>
                     <OutboundLink
-                      href={translations.one.buttonLink2}
+                      href={translations.one.button2Link}
                       className="tem-btn nav-link move-eff"
                     >
                       <span>{translations.one.button2}</span>


### PR DESCRIPTION
This PR does 3 simple things:

1. Fixes the Conference Site link from `global` => `conference`
2. Adds more confirmed speakers to `conference`
3. Adds `conference` app to ci/cd workflow


Closes #26  #25  #24 