### PR TITLE
feat(conference-mobile): get speaker and schedule updates from api on refresh pull

### DIFF
--- a/apps/conference-mobile/src/app/pages/SpeakerList.tsx
+++ b/apps/conference-mobile/src/app/pages/SpeakerList.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
-import React from 'react'
+import React, { useState } from 'react'
 import {
   IonHeader,
   IonToolbar,
@@ -11,6 +11,9 @@ import {
   IonGrid,
   IonRow,
   IonCol,
+  IonRefresher,
+  IonRefresherContent,
+  IonToast,
 } from '@ionic/react'
 import SpeakerItem from '../components/SpeakerItem'
 import { connect } from '../data/connect'
@@ -18,6 +21,8 @@ import * as selectors from '../data/selectors'
 import './SpeakerList.scss'
 import { Speaker } from '@dreamon/conference-speakers'
 import { Session } from '@dreamon/conference-schedule'
+import { RefresherEventDetail } from '@ionic/core'
+import { loadConfData } from '../data/sessions/sessions.actions'
 
 interface OwnProps {}
 
@@ -26,14 +31,29 @@ interface StateProps {
   speakerSessions: { [key: string]: Session[] }
 }
 
-interface DispatchProps {}
+interface DispatchProps {
+  loadConfData: typeof loadConfData
+}
 
 interface SpeakerListProps extends OwnProps, StateProps, DispatchProps {}
 
 const SpeakerList: React.FC<SpeakerListProps> = ({
   speakers,
   speakerSessions,
+  loadConfData,
 }) => {
+  const [refreshing, setRefreshing] = useState<boolean>(false)
+  const [showCompleteToast, setShowCompleteToast] = useState(false)
+
+  const doRefresh = (event: CustomEvent<RefresherEventDetail>) => {
+    setRefreshing(true)
+    loadConfData()
+    setTimeout(() => {
+      setShowCompleteToast(true)
+      setRefreshing(false)
+      event.detail.complete()
+    }, 2500)
+  }
   return (
     <IonPage id="speaker-list">
       <IonHeader translucent={true}>
@@ -52,19 +72,32 @@ const SpeakerList: React.FC<SpeakerListProps> = ({
           </IonToolbar>
         </IonHeader>
 
-        <IonGrid fixed>
-          <IonRow>
-            {speakers.map((speaker) => (
-              <IonCol size="12" size-md="6" key={speaker.id}>
-                <SpeakerItem
-                  key={speaker.id}
-                  speaker={speaker}
-                  sessions={speakerSessions[speaker.name]}
-                />
-              </IonCol>
-            ))}
-          </IonRow>
-        </IonGrid>
+        <IonRefresher slot="fixed" onIonRefresh={doRefresh}>
+          <IonRefresherContent />
+        </IonRefresher>
+
+        <IonToast
+          isOpen={showCompleteToast}
+          message="Refresh complete"
+          duration={2000}
+          onDidDismiss={() => setShowCompleteToast(false)}
+        />
+
+        {!refreshing ? (
+          <IonGrid fixed>
+            <IonRow>
+              {speakers.map((speaker) => (
+                <IonCol size="12" size-md="6" key={speaker.id}>
+                  <SpeakerItem
+                    key={speaker.id}
+                    speaker={speaker}
+                    sessions={speakerSessions[speaker.name]}
+                  />
+                </IonCol>
+              ))}
+            </IonRow>
+          </IonGrid>
+        ) : null}
       </IonContent>
     </IonPage>
   )
@@ -75,5 +108,8 @@ export default connect<OwnProps, StateProps, DispatchProps>({
     speakers: selectors.getSpeakers(state),
     speakerSessions: selectors.getSpeakerSessions(state),
   }),
+  mapDispatchToProps: {
+    loadConfData,
+  },
   component: React.memo(SpeakerList),
 })

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:mobile": "nx build conference-mobile",
     "mobile:open:ios": "nx run conference-mobile:open:ios",
     "mobile:open:android": "nx run conference-mobile:open:android",
-    "mobile:sync:ios": "nx run conference-mobile:sync:ios",
+    "mobile:sync:ios": "yarn build:mobile && nx run conference-mobile:sync:ios",
     "mobile:sync:android": "nx run conference-mobile:sync:android"
   },
   "private": true,


### PR DESCRIPTION
This PR adds a refresher to Speakers & Schedule page and fetches conference data from API on pull of the ionic refresher

Closes #46 